### PR TITLE
Fix the path to STL argument

### DIFF
--- a/stl2gltf.py
+++ b/stl2gltf.py
@@ -1,6 +1,6 @@
 import os
 
-def stl_to_gltf(binary_stl_path, out_path, is_binary):
+def stl_to_gltf(path_to_stl, out_path, is_binary):
     import struct
 
     gltf2 = '''


### PR DESCRIPTION
The python script did not work because the first argument of the stl_to_gltf fucntion on the stl2gltf.py was not used on the script. Instead the variable `path_to_stl` is used. The argument name was changed to `path_to_stl`. Now the script works as expected.